### PR TITLE
bugfix 300以上の数字が表示されるので次項を足す前に出力

### DIFF
--- a/git-practice.py
+++ b/git-practice.py
@@ -1,11 +1,7 @@
 # 300以下のフィボナッチ数列を奇数のみ表示
 a = 0
 b = 1
-while b <= 300:
+
+while a <= 300:
+    print(a)
     a, b = b, a+b
-    # 偶数の場合表示させない
-    if b % 2 == 0:
-        continue
-    print(b)
-    
-    


### PR DESCRIPTION
## 概要

377が表示される

## 修正

- 次項を、足してから出力ではなく出力してから足す。
- 偶数非表示のロジック削除